### PR TITLE
fix(settings): allow administrators to bypass branch protection rules

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -74,7 +74,8 @@ branches:
           - context: "Quality Gate"
             app_id: 15368
       # Required. Enforce all configured restrictions for administrators. Set to true to enforce required status checks for repository administrators. Set to null to disable.
-      enforce_admins: true
+      # Currently set to false to allow Github Actions to bypass branch protection
+      enforce_admins: false
       # Required. Restrict who can push to this branch. Team and user restrictions are only available for organization-owned repositories. Set to null to disable.
       restrictions: null
       required_linear_history: true


### PR DESCRIPTION
This change will allow GitHub Actions to bypass branch protection when bumping versions and publishing changelogs