### PR TITLE
feat!: rename branch protection check

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -71,7 +71,7 @@ branches:
         strict: true
         # Required. The list of status checks to require in order to merge into this branch
         checks:
-          - context: "Quality Gate"
+          - context: "Quality Gate | Core"
             app_id: 15368
       # Required. Enforce all configured restrictions for administrators. Set to true to enforce required status checks for repository administrators. Set to null to disable.
       # Currently set to false to allow Github Actions to bypass branch protection


### PR DESCRIPTION
BREAKING CHANGE: The required status check 'Quality Gate' was renamed to 'Quality Gate | Core'. Update workflows or integrations that depend on the old name.