### PR TITLE
feat: disable dependabot

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -6,8 +6,8 @@ repository:
   # Settings for Code security and analysis
   # Dependabot Alerts
   security:
-    enableVulnerabilityAlerts: true
-    enableAutomatedSecurityFixes: true
+    enableVulnerabilityAlerts: false
+    enableAutomatedSecurityFixes: false
 
   # The default branch for this repository.
   default_branch: main


### PR DESCRIPTION
Due to limitations in dependabot and the pnpm package manager, I will be switching to renovate. This PR disables dependabot as the organization-level default