### PR TITLE
fix: apply default ruleset glob and remove classic branch protection

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -48,3 +48,10 @@ collaborators:
     # * `push` - can pull and push, but not administer this repository.
     # * `admin` - can pull, push and administer this repository.
     permission: admin
+
+# Remove classic branch protection. Omitting this section leaves existing classic
+# rules in place because the branches plugin never runs. Empty protection deletes
+# the default-branch rule so only the suborg rulesets remain.
+branches:
+  - name: default
+    protection: null

--- a/.github/suborgs/default.yml
+++ b/.github/suborgs/default.yml
@@ -2,8 +2,10 @@
 # repos such as admin). New repos inherit this on create/sync — no per-repo file.
 # renovate-config is a separate suborg so it is not required to pass status checks.
 # A repo may belong to only one suborg, so this glob must not overlap that file.
+# Use minimatch negation (!name), not extglob (!(name)), which did not match repos
+# under safe-settings 2.1.17.
 suborgrepos:
-  - "!(renovate-config)"
+  - "!renovate-config"
 
 rulesets:
   - name: Default branch protection


### PR DESCRIPTION
## Summary
- The `repository_ruleset` Probot warning is harmless (webhook catalog lag in safe-settings 2.1.17). The real issue: `!(renovate-config)` matched no repos, so the catch-all ruleset never applied.
- Switch the default suborg glob to `!renovate-config` and set `branches[].protection: null` so classic protection is deleted instead of left behind.

## Test plan
- [ ] After merge, Safe Settings Sync creates `Default branch protection` on `github-actions-library` (and other non-excluded repos).
- [ ] Classic branch protection on `github-actions-library` `main` is gone.
- [ ] `renovate-config` still has its ruleset with no required status checks.


Made with [Cursor](https://cursor.com)