### PR TITLE
fix: default suborg ruleset never matched any repo (glob engine has no negation)

### DIFF
--- a/.github/suborgs/00-renovate-config.yml
+++ b/.github/suborgs/00-renovate-config.yml
@@ -1,5 +1,12 @@
 # Same default-branch rules as default.yml, but no required status checks.
 # Replaces the old .github/repos/renovate-config.yml branches override.
+#
+# Filename is prefixed "00-" so it sorts (and loads) BEFORE default.yml.
+# safe-settings 2.1.17's getSubOrgConfig() picks the first matching suborg
+# pattern in load order, so this exact-match exception must be registered
+# before default.yml's "*" catch-all — otherwise "*" would match
+# renovate-config first and this file would never be used. See default.yml
+# for the full explanation.
 suborgrepos:
   - renovate-config
 

--- a/.github/suborgs/default.yml
+++ b/.github/suborgs/default.yml
@@ -1,11 +1,20 @@
-# Apply a repository ruleset to every repo except renovate-config (and restricted
-# repos such as admin). New repos inherit this on create/sync — no per-repo file.
-# renovate-config is a separate suborg so it is not required to pass status checks.
-# A repo may belong to only one suborg, so this glob must not overlap that file.
-# Use minimatch negation (!name), not extglob (!(name)), which did not match repos
-# under safe-settings 2.1.17.
+# Apply a repository ruleset to every repo. New repos inherit this on
+# create/sync — no per-repo file needed.
+#
+# IMPORTANT — safe-settings 2.1.17 quirk: lib/glob.js is NOT minimatch. It has
+# no negation/extglob support at all. Any pattern without "*" is turned into a
+# plain substring regex (`.*<pattern>.*`), so "!renovate-config" matches
+# nothing (no repo name contains "!"). "*" is the only pattern this engine
+# treats as a real wildcard (it becomes `^([^/]*)$`, i.e. match everything).
+#
+# renovate-config needs an exception (no required status checks). Since we
+# can't exclude it here, it's handled by 00-renovate-config.yml, which must
+# sort alphabetically BEFORE this file: getSubOrgConfig() returns the FIRST
+# matching pattern in insertion order (insertion order == suborgs/ directory
+# listing order == alphabetical by filename), so the exact-match "renovate-config"
+# pattern must be registered before this "*" catch-all or "*" wins for every repo.
 suborgrepos:
-  - "!renovate-config"
+  - "*"
 
 rulesets:
   - name: Default branch protection


### PR DESCRIPTION
## Root cause

safe-settings 2.1.17's `lib/glob.js` is a small custom matcher, **not minimatch**, and has no `!` negation or extglob support. Any pattern without `*` becomes a plain substring regex (`.*<pattern>.*`). So `!renovate-config` matched **zero** repositories (no repo name literally contains `!`) — that's why the catch-all suborg in `.github/suborgs/default.yml` never applied a ruleset to `github-actions-library` or anything else, even though classic branch protection deletion (from `.github/settings.yml`) did work.

Verified this against the actual pinned version's `Glob` class in a local simulation:
- `"!renovate-config"` → matches nothing.
- `"*"` → the only pattern this engine treats as a real wildcard (`^([^/]*)$`).
- `"renovate-config"` (no `*`) → substring match, which is why that one worked before.

There's a second wrinkle: `getSubOrgConfig(repoName)` returns the **first matching pattern in insertion order**, and insertion order follows the `suborgs/` directory listing order (alphabetical by filename). So a catch-all `"*"` and an exact-match exception can collide — whichever file sorts first wins for the overlapping repo.

## Fix

- `.github/suborgs/default.yml`: `suborgrepos` changed from `["!renovate-config"]` to `["*"]`.
- Renamed `.github/suborgs/renovate-config.yml` → `.github/suborgs/00-renovate-config.yml` so it's loaded (and registered in the lookup map) *before* `default.yml`, guaranteeing the exact-match exception is checked before the `*` catch-all.

## Expected result after merge

- `github-actions-library`, `ui`, `admin`, and all other repos get the "Default branch protection" ruleset (deletion/force-push/linear-history/PR review/Quality Gate + App + admin bypass) via the `*` catch-all.
- `renovate-config` keeps its existing "Default branch protection" ruleset without the Quality Gate requirement.
- No repo-level file needed for any future new repo.

Made with [Cursor](https://cursor.com)